### PR TITLE
Fix BundID AIA Account Linking

### DIFF
--- a/src/main/java/de/ba/oiam/keycloak/bundid/SamlAuthenticationPreprocessorImpl.java
+++ b/src/main/java/de/ba/oiam/keycloak/bundid/SamlAuthenticationPreprocessorImpl.java
@@ -42,6 +42,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.protocol.saml.preprocessor.SamlAuthenticationPreprocessor;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.utils.KeycloakSessionUtil;
 import org.keycloak.utils.StringUtil;
 
 @AutoService(SamlAuthenticationPreprocessor.class)
@@ -152,7 +153,7 @@ public class SamlAuthenticationPreprocessorImpl implements SamlAuthenticationPre
     }
 
     private AuthnLevel getAuthnLevel(AuthenticationSessionModel authSession) {
-        AcrStore acrStore = new AcrStore(null, authSession);
+        AcrStore acrStore = new AcrStore(KeycloakSessionUtil.getKeycloakSession(), authSession);
         int loa = acrStore.getRequestedLevelOfAuthentication(null);
 
         if (minimumStorkLevel != null) {

--- a/src/test/java/de/ba/oiam/keycloak/bundid/SamlAuthenticationPreprocessorTest.java
+++ b/src/test/java/de/ba/oiam/keycloak/bundid/SamlAuthenticationPreprocessorTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.ba.oiam.keycloak.bundid.extension.model.AuthenticationRequest;
@@ -31,10 +32,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.keycloak.Config;
+import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.dom.saml.v2.protocol.AuthnContextComparisonType;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
 import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.utils.KeycloakSessionUtil;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 
@@ -59,6 +64,35 @@ class SamlAuthenticationPreprocessorTest {
         assertEquals(
                 List.of(AuthnLevel.STORK4.getFullname()),
                 expectedResult.getRequestedAuthnContext().getAuthnContextClassRef());
+    }
+
+    @Test
+    void authenticatedIdpLinkUsesCurrentKeycloakSession() {
+        final SamlAuthenticationPreprocessorImpl underTest = new SamlAuthenticationPreprocessorImpl();
+        final KeycloakSession keycloakSession = Mockito.mock(KeycloakSession.class);
+        final AuthenticationSessionModel authSession =
+                Mockito.mock(AuthenticationSessionModel.class, Answers.RETURNS_DEEP_STUBS);
+        final UserModel user = Mockito.mock(UserModel.class);
+        when(authSession.getAuthenticatedUser()).thenReturn(user);
+        when(authSession.getClientNote(Constants.REQUESTED_LEVEL_OF_AUTHENTICATION))
+                .thenReturn("3");
+        when(authSession.getClientNote(Constants.KC_ACTION)).thenReturn("idp_link");
+
+        final KeycloakSession previousSession = KeycloakSessionUtil.setKeycloakSession(keycloakSession);
+        AuthnRequestType result;
+        try {
+            result = underTest.beforeSendingLoginRequest(createBundIdAuthnRequest(), authSession);
+        } finally {
+            KeycloakSessionUtil.setKeycloakSession(previousSession);
+        }
+
+        verify(keycloakSession).getProvider(RequiredActionProvider.class, "idp_link");
+        assertEquals(
+                AuthnContextComparisonType.MINIMUM,
+                result.getRequestedAuthnContext().getComparison());
+        assertEquals(
+                List.of(AuthnLevel.STORK3.getFullname()),
+                result.getRequestedAuthnContext().getAuthnContextClassRef());
     }
 
     @Test


### PR DESCRIPTION
## Why

Authenticated BundID account linking (`kc_action=idp_link`) failed while normal BundID login and linking with different providers (MUK) continued to work. The BundID SAML preprocessor created `AcrStore` without a `KeycloakSession`. In the authenticated AIA path, Keycloak uses that session to resolve the required action provider. The resulting provider failure was then masked by a secondary Keycloak `EventBuilder` NPE.

## What Changed

The preprocessor now supplies Keycloak's current request session to `AcrStore`. A focused regression test covers the authenticated `idp_link` path, verifies the session is used, and checks the expected LoA output.

No flow-specific branching, Keycloak patch, or unrelated behavior was added.

## Verification

- `mvn -B clean install`
- 21 tests passed
- Spotless checks passed
